### PR TITLE
NixOS Module Hardening

### DIFF
--- a/config/example.json
+++ b/config/example.json
@@ -9,7 +9,7 @@
   "irc": {
     "host": "localhost",
     "port": 6667,
-    "tls": true
+    "tls": false
   },
   "controller": {
     "nick": "brockman",

--- a/module/default.nix
+++ b/module/default.nix
@@ -12,21 +12,38 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers.brockman.isSystemUser = true;
-
     systemd.services.brockman = {
       description = "RSS to IRC broadcaster";
+
       wantedBy = [ "multi-user.target" ];
       after = [ "network-online.target" ];
+
       serviceConfig = {
+        Type = "simple";
         Restart = "always";
         ExecStart = ''
           ${cfg.package}/bin/brockman ${pkgs.writeText "brockman.json" (builtins.toJSON cfg.config)}
         '';
-        User = config.users.extraUsers.brockman.name;
-        PrivateTmp = true;
+
+        WorkingDirectory = "~";
         RuntimeDirectory = "brockman";
-        WorkingDirectory = "%t/brockman";
+
+        DynamicUser = true;
+        NoNewPrivileges = true;
+
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        ProtectHome = "tmpfs";
+        PrivateTmp = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        MemoryDenyWriteExecute = true;
       };
     };
   };

--- a/module/default.nix
+++ b/module/default.nix
@@ -12,7 +12,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers.brockman.isNormalUser = false;
+    users.extraUsers.brockman.isSystemUser = true;
 
     systemd.services.brockman = {
       description = "RSS to IRC broadcaster";

--- a/vm-test/vm.nix
+++ b/vm-test/vm.nix
@@ -9,7 +9,7 @@
 
   systemd.services.brockman.environment.BROCKMAN_LOG_LEVEL = "DEBUG";
 
-  services.mingetty.autologinUser = "root";
+  services.getty.autologinUser = "root";
   programs.bash.promptInit = ''
     ${pkgs.tmux}/bin/tmux new-session \
       '${pkgs.epic5}/bin/epic5 -c "#news" listener localhost' \; \


### PR DESCRIPTION
This Pull Requests introduces two changes, each in its own commit.

* First, the upstream changes in the `nixpkgs` were reflected in both the NixOS module and test.
  This allows to run the test again.
  For this, TLS had to be deactivated in the sample configuration used as well.
* On this basis, the other change tries to harden the NixOS module resp. the created systemd unit by systemd's restrictions, documented wihtin `systemd.exec`.

Please feel free to comment on this requested changes. Thanks.