### PR TITLE
Revert "NixOS Module Hardening"

### DIFF
--- a/config/example.json
+++ b/config/example.json
@@ -9,7 +9,7 @@
   "irc": {
     "host": "localhost",
     "port": 6667,
-    "tls": false
+    "tls": true
   },
   "controller": {
     "nick": "brockman",

--- a/module/default.nix
+++ b/module/default.nix
@@ -12,7 +12,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers.brockman.isSystemUser = true;
+    users.extraUsers.brockman.isNormalUser = false;
 
     systemd.services.brockman = {
       description = "RSS to IRC broadcaster";

--- a/module/default.nix
+++ b/module/default.nix
@@ -12,38 +12,21 @@ in {
   };
 
   config = mkIf cfg.enable {
+    users.extraUsers.brockman.isSystemUser = true;
+
     systemd.services.brockman = {
       description = "RSS to IRC broadcaster";
-
       wantedBy = [ "multi-user.target" ];
       after = [ "network-online.target" ];
-
       serviceConfig = {
-        Type = "simple";
         Restart = "always";
         ExecStart = ''
           ${cfg.package}/bin/brockman ${pkgs.writeText "brockman.json" (builtins.toJSON cfg.config)}
         '';
-
-        WorkingDirectory = "~";
-        RuntimeDirectory = "brockman";
-
-        DynamicUser = true;
-        NoNewPrivileges = true;
-
-        ProtectProc = "invisible";
-        ProtectSystem = "strict";
-        ProtectHome = "tmpfs";
+        User = config.users.extraUsers.brockman.name;
         PrivateTmp = true;
-        PrivateDevices = true;
-        PrivateUsers = true;
-        ProtectHostname = true;
-        ProtectClock = true;
-        ProtectKernelTunables = true;
-        ProtectKernelModules = true;
-        ProtectKernelLogs = true;
-        ProtectControlGroups = true;
-        MemoryDenyWriteExecute = true;
+        RuntimeDirectory = "brockman";
+        WorkingDirectory = "%t/brockman";
       };
     };
   };

--- a/vm-test/vm.nix
+++ b/vm-test/vm.nix
@@ -9,7 +9,7 @@
 
   systemd.services.brockman.environment.BROCKMAN_LOG_LEVEL = "DEBUG";
 
-  services.getty.autologinUser = "root";
+  services.mingetty.autologinUser = "root";
   programs.bash.promptInit = ''
     ${pkgs.tmux}/bin/tmux new-session \
       '${pkgs.epic5}/bin/epic5 -c "#news" listener localhost' \; \


### PR DESCRIPTION
Reverts kmein/brockman#43

It seems @oxzi's changes broke the module.

### Steps to reproduce
1. Build and run the VM.
2. Message the controller bot: `brockman: tick bchan 4`
3. Observe: `/var/lib/brockman-state.json: openBinaryFile: permission denied (Read-only file system)`  