### PR TITLE
fix: replace control chars with space

### DIFF
--- a/src/Brockman/Bot.hs
+++ b/src/Brockman/Bot.hs
@@ -52,7 +52,10 @@ broadcastNotice channels message =
 broadcast :: Monad m => [Channel] -> [T.Text] -> ConduitT i (IRC.Message ByteString) m ()
 broadcast channels messages =
   sourceList
-    [ IRC.Privmsg (encode channel) $ Right $ encodeUtf8 message
+    [ IRC.Privmsg (encode channel) $ Right $ encodeIRCMessage message
       | channel <- channels,
         message <- messages
     ]
+
+encodeIRCMessage :: T.Text -> ByteString
+encodeIRCMessage = encodeUtf8 . T.map (\c -> if c `elem` ("\0\r\n" :: [Char]) then ' ' else c)


### PR DESCRIPTION
With this patch brockman doesn't crash on ergochat anymore