### PR TITLE
lrucaching -> lrucache

### DIFF
--- a/brockman.cabal
+++ b/brockman.cabal
@@ -27,7 +27,7 @@ executable brockman
     http-client,
     irc-conduit,
     lens,
-    lrucaching,
+    lrucache,
     network,
     optparse-applicative,
     random,

--- a/default.nix
+++ b/default.nix
@@ -1,21 +1,20 @@
 { mkDerivation, aeson, aeson-pretty, base, bytestring
 , case-insensitive, conduit, containers, directory, feed, filepath
 , hashable, hslogger, html-entity, http-client, irc-conduit, lens
-, lib, lrucaching, network, optparse-applicative, random, safe
-, text, time, timerep, unordered-containers, wreq
+, lib, lrucache, network, optparse-applicative, random, safe, text
+, time, timerep, unordered-containers, wreq
 }:
 mkDerivation {
   pname = "brockman";
-  version = "4.0.2";
+  version = "4.0.3";
   src = ./.;
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [
     aeson aeson-pretty base bytestring case-insensitive conduit
     containers directory feed filepath hashable hslogger html-entity
-    http-client irc-conduit lens lrucaching network
-    optparse-applicative random safe text time timerep
-    unordered-containers wreq
+    http-client irc-conduit lens lrucache network optparse-applicative
+    random safe text time timerep unordered-containers wreq
   ];
   license = lib.licenses.mit;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1640542138,
-        "narHash": "sha256-2f+Dslfzkuj0pgBl+70lkiTCg+U2Q0TcOikwxpsU+Fk=",
+        "lastModified": 1653339081,
+        "narHash": "sha256-dpim9Mtd57Yj6qt7p7UKwjWm6NnOU3S7jaEyEscSyPE=",
         "owner": "nix-community",
         "repo": "nixos-generators",
-        "rev": "296067b9c7a172d294831dec89d86847f30a7cfc",
+        "rev": "fb3ee0f618b8c80dea1239691b15dfeb4bb46331",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641334250,
-        "narHash": "sha256-phZavHnNA98Ub5gDeNFUt7fI4Y1S0mnGzqY4MCCgBNI=",
+        "lastModified": 1654012153,
+        "narHash": "sha256-In+gfoH2Tnf/UmpzeuGlfuexU2EC4QIelBsm2zMK5AE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "27ff8d72f5c9c38ca073f73dd0ae74e676fbb4f7",
+        "rev": "49a2bcc6e2065909c701f862f9a1a62b3082b40a",
         "type": "github"
       },
       "original": {

--- a/src/Brockman/Bot/Reporter.hs
+++ b/src/Brockman/Bot/Reporter.hs
@@ -19,7 +19,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Data.ByteString as BS (ByteString)
 import qualified Data.ByteString.Lazy as BL (toStrict)
 import Data.Conduit
-import Data.LruCache.Internal (LruCache (lruCapacity))
+import qualified Data.Cache.LRU as LRU
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T (Text, pack, unpack, unwords, words)
@@ -149,7 +149,7 @@ feedThread nick configMVar isFirstTime lru chan =
         unless isFirstTime $ writeList2Chan chan $ map NewFeedItem items
         return $ Just lru'
     tick <- scatterTick $ max 1 $ min 86400 $ fromMaybe fallbackDelay $ botDelay <|> newTick <|> defaultDelay
-    debug nick $ "lrusize: " <> show (maybe 0 lruCapacity newLRU)
+    debug nick $ "lrusize: " <> show (maybe 0 (fromMaybe 0 . LRU.maxSize) newLRU)
     notice nick $ "tick " <> show tick
     liftIO $ sleepSeconds tick
     feedThread nick configMVar False newLRU chan

--- a/src/Brockman/Feed.hs
+++ b/src/Brockman/Feed.hs
@@ -8,8 +8,7 @@ import Control.Applicative (Alternative (..))
 import Data.Fixed
 import Data.Hashable (hash)
 import Data.List
-import qualified Data.LruCache as LRU
-import Data.LruCache.Internal (LruCache (lruCapacity))
+import qualified Data.Cache.LRU as LRU
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Text (Text, intercalate, lines, pack, strip, unwords)
 import Data.Time.Clock
@@ -25,7 +24,7 @@ import Text.RSS.Syntax (RSSItem (rssItemPubDate))
 import qualified Text.RSS.Syntax as RSS
 import qualified Text.RSS1.Syntax as RSS1
 
-type LRU = LRU.LruCache Int ()
+type LRU = LRU.LRU Int ()
 
 data FeedItem = FeedItem
   { itemTitle :: Text,
@@ -84,14 +83,18 @@ deduplicate maybeLRU items =
     Nothing ->
       freshLru
     Just lru ->
-      if lruCapacity lru < genericLength items
-        then freshLru
-        else insertItems lru items
+      case LRU.maxSize lru of
+        Nothing ->
+          freshLru
+        Just capacity ->
+          if capacity < genericLength items
+            then freshLru
+            else insertItems lru items
   where
-    freshLru = insertItems (LRU.empty (genericLength items * 2)) items
+    freshLru = insertItems (LRU.newLRU (Just $ genericLength items * 2)) items
     key = hash . itemLink
     insertItems lru items' = foldl' step (lru, []) items'
     step (lru, items') item =
       case LRU.lookup (key item) lru of
-        Nothing -> (LRU.insert (key item) () lru, item : items')
-        Just ((), newLru) -> (newLru, items')
+        (newLRU, Nothing) -> (LRU.insert (key item) () newLRU, item : items')
+        (newLRU, Just ()) -> (newLRU, items')

--- a/src/Brockman/Types.hs
+++ b/src/Brockman/Types.hs
@@ -16,12 +16,13 @@ import qualified Data.ByteString.Lazy as BL
 import Data.CaseInsensitive (CI, foldedCase, mk)
 import Data.Char (isLower, toLower)
 import Data.Data (Data, constrFields, toConstr)
-import Data.HashMap.Strict (keys)
+import Data.Aeson.KeyMap (keys)
+import qualified Data.Aeson.Key
 import Data.List (intercalate)
 import Data.Map (Map, lookup)
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
-import Data.Text (Text, unpack)
+import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic, Rep)
@@ -151,7 +152,8 @@ parseStrictJSON jsonValue = checkExtraneousKeys myOptions jsonValue =<< genericP
     checkExtraneousKeys options value parsed =
       case value of
         Object o ->
-          let objectKeys = Set.fromList $ map unpack $ keys o
+          let objectKeys :: Set.Set String
+              objectKeys = Set.fromList $ map Data.Aeson.Key.toString $ keys o
               recordFields = Set.fromList $ fmap (fieldLabelModifier options) $ constrFields $ toConstr parsed
               difference = Set.difference objectKeys recordFields
            in if Set.null difference


### PR DESCRIPTION
still some aeson errors are happening, I guess they are unrelated to the LRU stuff, but not really sure.

```
Building executable 'brockman' for brockman-4.0.3..
[1 of 7] Compiling Brockman.Feed    ( src/Brockman/Feed.hs, dist/build/brockman/brockman-tmp/Brockman/Feed.o )
[2 of 7] Compiling Brockman.Types   ( src/Brockman/Types.hs, dist/build/brockman/brockman-tmp/Brockman/Types.o )

src/Brockman/Types.hs:154:61: error:
    • Couldn't match type: Data.Aeson.KeyMap.KeyMap Value
                     with: Data.HashMap.Internal.HashMap Text v0
      Expected: Data.HashMap.Internal.HashMap Text v0
        Actual: Object
    • In the first argument of ‘keys’, namely ‘o’
      In the second argument of ‘($)’, namely ‘keys o’
      In the second argument of ‘($)’, namely ‘map unpack $ keys o’
    |
154 |           let objectKeys = Set.fromList $ map unpack $ keys o
    |                                                             ^
error: builder for '/nix/store/f15ykbbbahj0qa7lxr7lq445241n4mna-brockman-4.0.3.drv' failed with exit code 1;
       last 10 log lines:
       >     • Couldn't match type: Data.Aeson.KeyMap.KeyMap Value
       >                      with: Data.HashMap.Internal.HashMap Text v0
       >       Expected: Data.HashMap.Internal.HashMap Text v0
       >         Actual: Object
       >     • In the first argument of ‘keys’, namely ‘o’
       >       In the second argument of ‘($)’, namely ‘keys o’
       >       In the second argument of ‘($)’, namely ‘map unpack $ keys o’
       >     |
       > 154 |           let objectKeys = Set.fromList $ map unpack $ keys o
       >     |                                                             ^
       For full logs, run 'nix log /nix/store/f15ykbbbahj0qa7lxr7lq445241n4mna-brockman-4.0.3.drv
```