### PR TITLE
feat: let title fallback to description in RSS2.0

### DIFF
--- a/src/Brockman/Feed.hs
+++ b/src/Brockman/Feed.hs
@@ -79,7 +79,7 @@ feedToItems = maybe [] (mapMaybe fromItem . feedItems)
             date = Atom.entryPublished entry
          in FeedItem title date <$> link
       Feed.RSSItem item ->
-        let title = fromMaybe "untitled" (RSS.rssItemTitle item)
+        let title = fromMaybe (fromMaybe "untitled" (RSS.rssItemDescription item)) (RSS.rssItemTitle item)
             link = RSS.rssItemLink item
             date = RSS.rssItemPubDate item
          in FeedItem title date <$> link

--- a/src/Brockman/Feed.hs
+++ b/src/Brockman/Feed.hs
@@ -79,7 +79,7 @@ feedToItems = maybe [] (mapMaybe fromItem . feedItems)
             date = Atom.entryPublished entry
          in FeedItem title date <$> link
       Feed.RSSItem item ->
-        let title = fromMaybe (fromMaybe "untitled" (RSS.rssItemDescription item)) (RSS.rssItemTitle item)
+        let title = fromMaybe "untitled" (RSS.rssItemTitle item <|> RSS.rssItemDescription item)
             link = RSS.rssItemLink item
             date = RSS.rssItemPubDate item
          in FeedItem title date <$> link


### PR DESCRIPTION
maybe we could also fallback on content if that exists?
there is probably a way to make it nicer with a monad, but not sure how :)